### PR TITLE
support strict mode in toJsonSchema helper

### DIFF
--- a/src/codecTools/toJsonSchema.ts
+++ b/src/codecTools/toJsonSchema.ts
@@ -27,6 +27,7 @@ type MappableType =
  * Convert an io-ts codec to a JSON Schema (v7)
  *
  * @param _type - an io-ts codec
+ * @param strict - whether to enable strict mode
  * @returns a JSON schema object
  * @see https://json-schema.org/understanding-json-schema/basics.html
  */

--- a/src/codecTools/toJsonSchema.ts
+++ b/src/codecTools/toJsonSchema.ts
@@ -68,7 +68,7 @@ export const toJsonSchema = (_type: any, strict = false): JSONSchema7 => {
           toJsonSchema(subtype),
         ]),
       ),
-      ...(strict ? { additionalProperties: false } : {})
+      ...(strict ? { additionalProperties: false } : {}),
     };
   }
   if (type._tag === 'DictionaryType') {
@@ -86,7 +86,7 @@ export const toJsonSchema = (_type: any, strict = false): JSONSchema7 => {
           toJsonSchema(subtype),
         ]),
       ),
-      ...(strict ? { additionalProperties: false } : {})
+      ...(strict ? { additionalProperties: false } : {}),
     };
   }
   if (type._tag === 'ArrayType') {

--- a/src/codecTools/toJsonSchema.ts
+++ b/src/codecTools/toJsonSchema.ts
@@ -67,7 +67,7 @@ export const toJsonSchema = (_type: any, strict = false): JSONSchema7 => {
           toJsonSchema(subtype),
         ]),
       ),
-      ...(strict ? {additionalProperties: false} : {})
+      ...(strict ? { additionalProperties: false } : {})
     };
   }
   if (type._tag === 'DictionaryType') {
@@ -85,7 +85,7 @@ export const toJsonSchema = (_type: any, strict = false): JSONSchema7 => {
           toJsonSchema(subtype),
         ]),
       ),
-      ...(strict ? {additionalProperties: false} : {})
+      ...(strict ? { additionalProperties: false } : {})
     };
   }
   if (type._tag === 'ArrayType') {

--- a/src/codecTools/toJsonSchema.ts
+++ b/src/codecTools/toJsonSchema.ts
@@ -30,7 +30,7 @@ type MappableType =
  * @returns a JSON schema object
  * @see https://json-schema.org/understanding-json-schema/basics.html
  */
-export const toJsonSchema = (_type: any): JSONSchema7 => {
+export const toJsonSchema = (_type: any, strict = false): JSONSchema7 => {
   const type = _type as MappableType;
 
   if (type._tag === 'StringType') {
@@ -67,6 +67,7 @@ export const toJsonSchema = (_type: any): JSONSchema7 => {
           toJsonSchema(subtype),
         ]),
       ),
+      ...(strict ? {additionalProperties: false} : {})
     };
   }
   if (type._tag === 'DictionaryType') {
@@ -84,6 +85,7 @@ export const toJsonSchema = (_type: any): JSONSchema7 => {
           toJsonSchema(subtype),
         ]),
       ),
+      ...(strict ? {additionalProperties: false} : {})
     };
   }
   if (type._tag === 'ArrayType') {


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-28290

- This updates the `toJsonSchema` helper to support "strict mode", meaning that properties whose names are not listed in the "properties" keyword of the schema would not be allowed (see [here](https://json-schema.org/understanding-json-schema/reference/object.html?highlight=additionalproperties#id5))
- We set strict = false by default so these changes are backwards compatible.