### PR TITLE
add interface validation type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,3 +254,15 @@ export type DeepPartial<T> = {
  * TODO: https://transcend.height.app/T-15646 - Remove once on TypeScript 4.5.
  */
 export type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+
+/**
+ * Utility type that passes through the interface given that its keys are exactly equal to the keys string union
+ */
+export type KeysStrictlyEqual<
+  Keys extends string,
+  Interface extends [keyof Interface] extends [Keys]
+    ? [Keys] extends [keyof Interface]
+      ? unknown
+      : never
+    : never,
+> = Interface;


### PR DESCRIPTION
Adds a validation type to ensure an interface specifies all the keys it should be specifying

For example:

```
type KeyUnion = 'a' | 'b' | 'c';
type Error1 = KeysStrictlyEqual<KeyUnion, { a: string }> // error
type Error2 = KeysStrictlyEqual<KeyUnion, { a: string, b: string, c: string, d: string }> // error
type ValidInterface = KeysStrictlyEqual<KeyUnion, { a: string, b: string, c: string }> // success, type ValidInterface is equal to { a: string, b: string, c: string }
```