### PR TITLE
Re-work the decodeCodec function to return useful information.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,9 +33,10 @@ repos:
   - repo: local
     hooks:
       - id: eslint
-        name: Eslint
-        description: 'Run static code linting'
-        entry: yarn lint --fix
+        name: ESLint
         language: node
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+        entry: yarn
+        args: [run, eslint, --fix, --quiet]
         types: [file]
+        files: .*\.(js|jsx|ts|tsx)$
+        exclude: (.yarn)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,3 @@ repos:
         args: [run, eslint, --fix, --quiet]
         types: [file]
         files: .*\.(js|jsx|ts|tsx)$
-        exclude: (.yarn)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/codecTools/decodeCodec.ts
+++ b/src/codecTools/decodeCodec.ts
@@ -1,38 +1,50 @@
 // external
-import { fold } from 'fp-ts/lib/Either';
-import { pipe } from 'fp-ts/lib/pipeable';
+import {fold} from 'fp-ts/lib/Either';
+import {isLeft} from 'fp-ts/Either';
+import {pipe} from 'fp-ts/lib/pipeable';
 import * as t from 'io-ts';
 
-// Determine the paths of the codec that are invalid
-const getPaths = <A>(v: t.Validation<A>): string[] =>
-  pipe(
+/**
+ * Determine the codec paths that are invalid.
+ *
+ * @param v - Validation errors.
+ * @returns The error strings formatted for human consumption.
+ */
+function getPaths  <A>(v: t.Validation<A>): string[]  {
+  return pipe(
     v,
     fold(
       (errors) =>
         errors.map((error) => {
-          const lastError = error.context[error.context.length - 1];
-          return `${error.context
-            .map((context) => context.key)
-            // Note: lastError.actual is helpful for debugging
-            .join('.')} expected type '${lastError.type.name}'`;
+          const lastCtx = error.context.at(-1);
+          const fullPath = error.context.map(({ key }) => key).join('.');
+          return `${fullPath} expected type '${lastCtx?.type.name}'`;
         }),
 
       () => ['no errors'],
     ),
   );
+}
 
-// Get custom error messages for the errors
-const getCustomErrors = <A>(
+/**
+ * Get custom error messages for the errors.
+ *
+ * @param v - Validation errors.
+ * @param customErrorFromContext - Custom mapper function.
+ * @returns The custom error strings formatted for human consumption.
+ */
+function getCustomErrors  <A>(
   v: t.Validation<A>,
   customErrorFromContext: (validationContext: t.Context) => string,
-): string[] =>
-  pipe(
+): string[]  {
+  return pipe(
     v,
     fold(
       (errors) => errors.map((error) => customErrorFromContext(error.context)),
       () => ['no errors'],
     ),
   );
+}
 
 export const CODEC_ERROR_MESSAGE = 'Failed to decode codec:';
 
@@ -48,26 +60,25 @@ export function decodeCodec<TCodec extends t.Any>(
   codec: TCodec,
   txt: string | object | object[] | null | unknown,
   parse = true,
-  // Warning: DO NOT LOG SENSITIVE DATA WITH THIS!
-  customErrorFromContext: (validationContext: t.Context) => string = () => '',
+  customErrorFromContext?: (validationContext: t.Context) => string,
 ): t.TypeOf<TCodec> {
   // uncomment the below to view the response pre-decode
   const decoded = codec.decode(
     parse && typeof txt === 'string' ? JSON.parse(txt) : txt,
   );
   // Log errors on failure
-  // eslint-disable-next-line no-underscore-dangle
-  if (decoded._tag === 'Left') {
+  if (isLeft(decoded)) {
+    const errorPaths = getPaths(decoded);
+    const customError = customErrorFromContext !== undefined ? JSON.stringify(
+      getCustomErrors(decoded, customErrorFromContext),
+      null, 2
+    ) : undefined;
     throw new Error(
-      `${CODEC_ERROR_MESSAGE} \n\n${JSON.stringify(
-        getPaths(decoded),
+      `${CODEC_ERROR_MESSAGE} ${JSON.stringify(
+        errorPaths,
         null,
         2,
-      )}${JSON.stringify(
-        getCustomErrors(decoded, customErrorFromContext),
-        null,
-        2,
-      )}`,
+      )}${customError ?? ''}`,
     );
   }
 

--- a/src/codecTools/decodeCodec.ts
+++ b/src/codecTools/decodeCodec.ts
@@ -1,16 +1,13 @@
-// external
-import {fold} from 'fp-ts/lib/Either';
-import {isLeft} from 'fp-ts/Either';
-import {pipe} from 'fp-ts/lib/pipeable';
+import { fold, isLeft } from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/pipeable';
 import * as t from 'io-ts';
 
 /**
  * Determine the codec paths that are invalid.
- *
  * @param v - Validation errors.
  * @returns The error strings formatted for human consumption.
  */
-function getPaths  <A>(v: t.Validation<A>): string[]  {
+function getPaths<A>(v: t.Validation<A>): string[] {
   return pipe(
     v,
     fold(
@@ -28,15 +25,14 @@ function getPaths  <A>(v: t.Validation<A>): string[]  {
 
 /**
  * Get custom error messages for the errors.
- *
  * @param v - Validation errors.
  * @param customErrorFromContext - Custom mapper function.
  * @returns The custom error strings formatted for human consumption.
  */
-function getCustomErrors  <A>(
+function getCustomErrors<A>(
   v: t.Validation<A>,
   customErrorFromContext: (validationContext: t.Context) => string,
-): string[]  {
+): string[] {
   return pipe(
     v,
     fold(
@@ -60,7 +56,9 @@ export function decodeCodec<TCodec extends t.Any>(
   codec: TCodec,
   txt: string | object | object[] | null | unknown,
   parse = true,
-  customErrorFromContext?: (validationContext: t.Context) => string,
+  customErrorFromContext:
+    | ((validationContext: t.Context) => string)
+    | undefined = undefined,
 ): t.TypeOf<TCodec> {
   // uncomment the below to view the response pre-decode
   const decoded = codec.decode(
@@ -69,16 +67,18 @@ export function decodeCodec<TCodec extends t.Any>(
   // Log errors on failure
   if (isLeft(decoded)) {
     const errorPaths = getPaths(decoded);
-    const customError = customErrorFromContext !== undefined ? JSON.stringify(
-      getCustomErrors(decoded, customErrorFromContext),
-      null, 2
-    ) : undefined;
+    const customError =
+      customErrorFromContext !== undefined
+        ? JSON.stringify(
+            getCustomErrors(decoded, customErrorFromContext),
+            null,
+            2,
+          )
+        : undefined;
     throw new Error(
-      `${CODEC_ERROR_MESSAGE} ${JSON.stringify(
-        errorPaths,
-        null,
-        2,
-      )}${customError ?? ''}`,
+      `${CODEC_ERROR_MESSAGE} ${JSON.stringify(errorPaths, null, 2)}${
+        customError ?? ''
+      }`,
     );
   }
 

--- a/src/tests/decodeCodec.test.ts
+++ b/src/tests/decodeCodec.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import * as t from 'io-ts';
+import { decodeCodec } from '../codecTools';
+
+describe('decodeCodec', () => {
+  it('should decode a codec as expected', () => {
+    const c = t.type({
+      str: t.string,
+      num: t.number,
+      headers: t.record(t.string, t.string),
+    });
+    const obj = {
+      str: 'abcd',
+      num: 123,
+      headers: {
+        yolo: 'one-life',
+      },
+    };
+    const decoded = decodeCodec(c, obj);
+    expect(decoded).to.deep.equal(obj);
+  });
+
+  it('should throw an error when the input does not match the codec', () => {
+    const c = t.type({
+      str: t.string,
+      num: t.number,
+      headers: t.record(t.string, t.string),
+    });
+    const obj = {
+      str: 123,
+      num: 123,
+      headers: {
+        yolo: 'one-life',
+      },
+    };
+    try {
+      decodeCodec(c, obj);
+    } catch (e) {
+      expect(e.message).to.equal(
+        'Failed to decode codec: [\n  ".str expected type \'string\'"\n]',
+      );
+    }
+  });
+});

--- a/src/tests/decodeCodec.test.ts
+++ b/src/tests/decodeCodec.test.ts
@@ -35,7 +35,7 @@ describe('decodeCodec', () => {
     };
     try {
       decodeCodec(c, obj);
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).to.equal(
         'Failed to decode codec: [\n  ".str expected type \'string\'"\n]',
       );

--- a/src/tests/decodeCodec.test.ts
+++ b/src/tests/decodeCodec.test.ts
@@ -35,6 +35,7 @@ describe('decodeCodec', () => {
     };
     try {
       decodeCodec(c, obj);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       expect(e.message).to.equal(
         'Failed to decode codec: [\n  ".str expected type \'string\'"\n]',


### PR DESCRIPTION
We're logging lots of whitespace when encountering codec failures, and these empty trailing spaces which are really annoying to look at.

https://app.datadoghq.com/logs?query=%22Failed%20to%20decode%20codec%22%20&cols=service%2Ccontainer%2C%40location%2C%40req.headers.x-sombra-saas-host%2C%40res.statusCode%2C%40dataSilo.type&event=AgAAAY459maKIXW60gAAAAAAAAAYAAAAAEFZNDU5dEVZQUFESE5wOHR2WmFtX0FBZQAAACQAAAAAMDE4ZTM5ZjgtNmNkNi00Y2E0LWIxMTAtZjc3NWJmMjQ0YzA3&index=%2A&messageDisplay=inline&storage=hot&stream_sort=desc&viz=stream

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
