### PR TITLE
add includeOtherProperties to transposeObjectArray

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/tests/transposeObjectArray.test.ts
+++ b/src/tests/transposeObjectArray.test.ts
@@ -3,7 +3,7 @@ import { transposeObjectArray } from '../transposeObjectArray';
 
 describe('transposeObjectArray', () => {
   it('should handle empty array', () => {
-    const result = transposeObjectArray({objects: [], properties: ['id', 'name']});
+    const result = transposeObjectArray({ objects: [], properties: ['id', 'name'] });
     expect(result).to.deep.equal({});
   });
 
@@ -12,7 +12,7 @@ describe('transposeObjectArray', () => {
       { id: 1, name: 'John', age: 25, city: 'NY' },
       { id: 2, name: 'Jane', age: 30, city: 'LA' },
     ];
-    const result = transposeObjectArray({objects, properties: ['id', 'name']});
+    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: ['John', 'Jane'],
@@ -29,7 +29,7 @@ describe('transposeObjectArray', () => {
       { id: 2, age: 30 },
       { id: 3, name: 'Bob', city: 'LA' },
     ];
-    const result = transposeObjectArray({objects, properties: ['id', 'name']});
+    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
     expect(result).to.deep.equal({
       id: [1, 2, 3],
       name: ['John', undefined, 'Bob'],
@@ -42,7 +42,7 @@ describe('transposeObjectArray', () => {
       { id: 1, active: true, count: 10, tags: ['a', 'b'] },
       { id: 2, active: false, count: 20, tags: ['c'] },
     ];
-    const result = transposeObjectArray({objects, properties: ['active', 'tags']});
+    const result = transposeObjectArray({ objects, properties: ['active', 'tags'] });
     expect(result).to.deep.equal({
       active: [true, false],
       tags: [['a', 'b'], ['c']],
@@ -58,7 +58,7 @@ describe('transposeObjectArray', () => {
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
     ];
-    const result = transposeObjectArray({objects, properties: ['id', 'name']});
+    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: ['John', 'Jane'],
@@ -71,7 +71,7 @@ describe('transposeObjectArray', () => {
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
     ];
-    const result = transposeObjectArray({objects, properties: []});
+    const result = transposeObjectArray({ objects, properties: [] });
     expect(result).to.deep.equal({
       rest: [
         { id: 1, name: 'John' },
@@ -85,7 +85,7 @@ describe('transposeObjectArray', () => {
       { id: 1, name: null, age: 25 },
       { id: 2, name: undefined, age: 30 },
     ];
-    const result = transposeObjectArray({objects, properties: ['id', 'name']});
+    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: [null, undefined],
@@ -98,7 +98,7 @@ describe('transposeObjectArray', () => {
       { id: 1, user: { name: 'John', age: 25 } },
       { id: 2, user: { name: 'Jane', age: 30 } },
     ];
-    const result = transposeObjectArray({objects, properties: ['id', 'user']});
+    const result = transposeObjectArray({ objects, properties: ['id', 'user'] });
     expect(result).to.deep.equal({
       id: [1, 2],
       user: [
@@ -114,7 +114,7 @@ describe('transposeObjectArray', () => {
       { a: 1, b: 2, c: 3, d: 4 },
       { a: 5, b: 6, c: 7, d: 8 },
     ];
-    const result = transposeObjectArray({objects, properties: ['a', 'c']});
+    const result = transposeObjectArray({ objects, properties: ['a', 'c'] });
     expect(result).to.deep.equal({
       a: [1, 5],
       c: [3, 7],
@@ -130,7 +130,7 @@ describe('transposeObjectArray', () => {
       { id: 1, name: null, age: 25 },
       { id: 2, name: undefined, age: 30 },
     ];
-    const result = transposeObjectArray({objects, properties: ['id', 'name'], options: {includeOtherProperties: false}});
+    const result = transposeObjectArray({ objects, properties: ['id', 'name'], options: { includeOtherProperties: false } });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: [null, undefined],

--- a/src/tests/transposeObjectArray.test.ts
+++ b/src/tests/transposeObjectArray.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { transposeObjectArray } from '../transposeObjectArray';
 
-describe.only('transposeObjectArray', () => {
+describe('transposeObjectArray', () => {
   it('should handle empty array', () => {
     const result = transposeObjectArray({objects: [], properties: ['id', 'name']});
     expect(result).to.deep.equal({});

--- a/src/tests/transposeObjectArray.test.ts
+++ b/src/tests/transposeObjectArray.test.ts
@@ -3,7 +3,10 @@ import { transposeObjectArray } from '../transposeObjectArray';
 
 describe('transposeObjectArray', () => {
   it('should handle empty array', () => {
-    const result = transposeObjectArray({ objects: [], properties: ['id', 'name'] });
+    const result = transposeObjectArray({
+      objects: [],
+      properties: ['id', 'name'],
+    });
     expect(result).to.deep.equal({});
   });
 
@@ -12,7 +15,10 @@ describe('transposeObjectArray', () => {
       { id: 1, name: 'John', age: 25, city: 'NY' },
       { id: 2, name: 'Jane', age: 30, city: 'LA' },
     ];
-    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['id', 'name'],
+    });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: ['John', 'Jane'],
@@ -29,7 +35,10 @@ describe('transposeObjectArray', () => {
       { id: 2, age: 30 },
       { id: 3, name: 'Bob', city: 'LA' },
     ];
-    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['id', 'name'],
+    });
     expect(result).to.deep.equal({
       id: [1, 2, 3],
       name: ['John', undefined, 'Bob'],
@@ -42,7 +51,10 @@ describe('transposeObjectArray', () => {
       { id: 1, active: true, count: 10, tags: ['a', 'b'] },
       { id: 2, active: false, count: 20, tags: ['c'] },
     ];
-    const result = transposeObjectArray({ objects, properties: ['active', 'tags'] });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['active', 'tags'],
+    });
     expect(result).to.deep.equal({
       active: [true, false],
       tags: [['a', 'b'], ['c']],
@@ -58,7 +70,10 @@ describe('transposeObjectArray', () => {
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
     ];
-    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['id', 'name'],
+    });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: ['John', 'Jane'],
@@ -85,7 +100,10 @@ describe('transposeObjectArray', () => {
       { id: 1, name: null, age: 25 },
       { id: 2, name: undefined, age: 30 },
     ];
-    const result = transposeObjectArray({ objects, properties: ['id', 'name'] });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['id', 'name'],
+    });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: [null, undefined],
@@ -98,7 +116,10 @@ describe('transposeObjectArray', () => {
       { id: 1, user: { name: 'John', age: 25 } },
       { id: 2, user: { name: 'Jane', age: 30 } },
     ];
-    const result = transposeObjectArray({ objects, properties: ['id', 'user'] });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['id', 'user'],
+    });
     expect(result).to.deep.equal({
       id: [1, 2],
       user: [
@@ -130,7 +151,11 @@ describe('transposeObjectArray', () => {
       { id: 1, name: null, age: 25 },
       { id: 2, name: undefined, age: 30 },
     ];
-    const result = transposeObjectArray({ objects, properties: ['id', 'name'], options: { includeOtherProperties: false } });
+    const result = transposeObjectArray({
+      objects,
+      properties: ['id', 'name'],
+      options: { includeOtherProperties: false },
+    });
     expect(result).to.deep.equal({
       id: [1, 2],
       name: [null, undefined],

--- a/src/tests/transposeObjectArray.test.ts
+++ b/src/tests/transposeObjectArray.test.ts
@@ -1,18 +1,18 @@
 import { expect } from 'chai';
 import { transposeObjectArray } from '../transposeObjectArray';
 
-describe('transposeObjectArray', () => {
+describe.only('transposeObjectArray', () => {
   it('should handle empty array', () => {
-    const result = transposeObjectArray([], ['id', 'name']);
+    const result = transposeObjectArray({objects: [], properties: ['id', 'name']});
     expect(result).to.deep.equal({});
   });
 
   it('should extract multiple properties from array of objects', () => {
-    const items = [
+    const objects = [
       { id: 1, name: 'John', age: 25, city: 'NY' },
       { id: 2, name: 'Jane', age: 30, city: 'LA' },
     ];
-    const result = transposeObjectArray(items, ['id', 'name']);
+    const result = transposeObjectArray({objects, properties: ['id', 'name']});
     expect(result).to.deep.equal({
       id: [1, 2],
       name: ['John', 'Jane'],
@@ -24,12 +24,12 @@ describe('transposeObjectArray', () => {
   });
 
   it('should handle objects with missing properties', () => {
-    const items = [
+    const objects = [
       { id: 1, name: 'John', age: 25 },
       { id: 2, age: 30 },
       { id: 3, name: 'Bob', city: 'LA' },
     ];
-    const result = transposeObjectArray(items, ['id', 'name']);
+    const result = transposeObjectArray({objects, properties: ['id', 'name']});
     expect(result).to.deep.equal({
       id: [1, 2, 3],
       name: ['John', undefined, 'Bob'],
@@ -38,11 +38,11 @@ describe('transposeObjectArray', () => {
   });
 
   it('should handle different value types', () => {
-    const items = [
+    const objects = [
       { id: 1, active: true, count: 10, tags: ['a', 'b'] },
       { id: 2, active: false, count: 20, tags: ['c'] },
     ];
-    const result = transposeObjectArray(items, ['active', 'tags']);
+    const result = transposeObjectArray({objects, properties: ['active', 'tags']});
     expect(result).to.deep.equal({
       active: [true, false],
       tags: [['a', 'b'], ['c']],
@@ -54,11 +54,11 @@ describe('transposeObjectArray', () => {
   });
 
   it('should handle extracting all properties (empty rest)', () => {
-    const items = [
+    const objects = [
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
     ];
-    const result = transposeObjectArray(items, ['id', 'name']);
+    const result = transposeObjectArray({objects, properties: ['id', 'name']});
     expect(result).to.deep.equal({
       id: [1, 2],
       name: ['John', 'Jane'],
@@ -67,11 +67,11 @@ describe('transposeObjectArray', () => {
   });
 
   it('should handle extracting no properties (everything in rest)', () => {
-    const items = [
+    const objects = [
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
     ];
-    const result = transposeObjectArray(items, []);
+    const result = transposeObjectArray({objects, properties: []});
     expect(result).to.deep.equal({
       rest: [
         { id: 1, name: 'John' },
@@ -81,11 +81,11 @@ describe('transposeObjectArray', () => {
   });
 
   it('should handle objects with null or undefined values', () => {
-    const items = [
+    const objects = [
       { id: 1, name: null, age: 25 },
       { id: 2, name: undefined, age: 30 },
     ];
-    const result = transposeObjectArray(items, ['id', 'name']);
+    const result = transposeObjectArray({objects, properties: ['id', 'name']});
     expect(result).to.deep.equal({
       id: [1, 2],
       name: [null, undefined],
@@ -94,11 +94,11 @@ describe('transposeObjectArray', () => {
   });
 
   it('should handle nested objects', () => {
-    const items = [
+    const objects = [
       { id: 1, user: { name: 'John', age: 25 } },
       { id: 2, user: { name: 'Jane', age: 30 } },
     ];
-    const result = transposeObjectArray(items, ['id', 'user']);
+    const result = transposeObjectArray({objects, properties: ['id', 'user']});
     expect(result).to.deep.equal({
       id: [1, 2],
       user: [
@@ -110,11 +110,11 @@ describe('transposeObjectArray', () => {
   });
 
   it('should preserve property order in rest object', () => {
-    const items = [
+    const objects = [
       { a: 1, b: 2, c: 3, d: 4 },
       { a: 5, b: 6, c: 7, d: 8 },
     ];
-    const result = transposeObjectArray(items, ['a', 'c']);
+    const result = transposeObjectArray({objects, properties: ['a', 'c']});
     expect(result).to.deep.equal({
       a: [1, 5],
       c: [3, 7],
@@ -122,6 +122,18 @@ describe('transposeObjectArray', () => {
         { b: 2, d: 4 },
         { b: 6, d: 8 },
       ],
+    });
+  });
+
+  it('should omit rest properties if includeOtherProperties is false', () => {
+    const objects = [
+      { id: 1, name: null, age: 25 },
+      { id: 2, name: undefined, age: 30 },
+    ];
+    const result = transposeObjectArray({objects, properties: ['id', 'name'], options: {includeOtherProperties: false}});
+    expect(result).to.deep.equal({
+      id: [1, 2],
+      name: [null, undefined],
     });
   });
 });

--- a/src/transposeObjectArray.ts
+++ b/src/transposeObjectArray.ts
@@ -85,8 +85,7 @@ export const transposeObjectArray = <T extends object, K extends keyof T>(
         }
       });
 
-      if(options.includeOtherProperties) {
-
+      if (options.includeOtherProperties) {
         result.rest = [...(acc.rest || []), restObject];
       }
 

--- a/src/transposeObjectArray.ts
+++ b/src/transposeObjectArray.ts
@@ -42,15 +42,14 @@ type TransposedObjectArray<T, K extends keyof T> = {
  * while keeping the remaining properties grouped in a 'rest' array.
  * @template T - The type of objects in the input array
  * @template K - The keys of properties to transpose
- * @param items - Array of objects to transpose
- * @param properties - Array of property keys to transpose into arrays
+ * @param param - the objects, properties, and transposing options
  * @returns An object containing transposed arrays for each selected property
  * @example
- * const items = [
+ * const objects = [
  *   { id: 1, name: 'John', age: 25 },
  *   { id: 2, name: 'Jane', age: 30 }
  * ]
- * const result = transposeObjectArray(items, ['id', 'name']);
+ * const result = transposeObjectArray({objects, properties: ['id', 'name']});
  * // Returns: {
  * //   id: [1, 2],
  * //   name: ['John', 'Jane'],
@@ -58,10 +57,19 @@ type TransposedObjectArray<T, K extends keyof T> = {
  * // }
  */
 export const transposeObjectArray = <T extends object, K extends keyof T>(
-  items: T[],
-  properties: K[],
+  { objects, properties, options = { includeOtherProperties: true } }: {
+    /** Array of objects to transpose */
+    objects: T[];
+  /** Array of property keys to transpose into arrays */
+  properties: K[];
+  /** Options for how to transpose the array */
+  options?: {
+    /** Whether to include non-tranposed properties in the final result */
+    includeOtherProperties?: boolean;
+  }
+  }
 ): TransposedObjectArray<T, K> =>
-  items.reduce(
+  objects.reduce(
     (acc, item) => {
       const result = { ...acc } as TransposedObjectArray<T, K>;
 
@@ -77,7 +85,10 @@ export const transposeObjectArray = <T extends object, K extends keyof T>(
         }
       });
 
-      result.rest = [...(acc.rest || []), restObject];
+      if(options.includeOtherProperties) {
+
+        result.rest = [...(acc.rest || []), restObject];
+      }
 
       return result;
     },

--- a/src/transposeObjectArray.ts
+++ b/src/transposeObjectArray.ts
@@ -56,19 +56,21 @@ type TransposedObjectArray<T, K extends keyof T> = {
  * //   rest: [{age: 25}, {age: 30}]
  * // }
  */
-export const transposeObjectArray = <T extends object, K extends keyof T>(
-  { objects, properties, options = { includeOtherProperties: true } }: {
-    /** Array of objects to transpose */
-    objects: T[];
+export const transposeObjectArray = <T extends object, K extends keyof T>({
+  objects,
+  properties,
+  options = { includeOtherProperties: true },
+}: {
+  /** Array of objects to transpose */
+  objects: T[];
   /** Array of property keys to transpose into arrays */
   properties: K[];
   /** Options for how to transpose the array */
   options?: {
     /** Whether to include non-tranposed properties in the final result */
     includeOtherProperties?: boolean;
-  }
-  }
-): TransposedObjectArray<T, K> =>
+  };
+}): TransposedObjectArray<T, K> =>
   objects.reduce(
     (acc, item) => {
       const result = { ...acc } as TransposedObjectArray<T, K>;


### PR DESCRIPTION
- adds `includeOtherProperties` option to the `transposeObjectArray` function. It determines whether to include non-transposed properties in the returned result.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
