### PR TITLE
update createDefaultCodec to handle literal types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/codecTools/createDefaultCodec.ts
+++ b/src/codecTools/createDefaultCodec.ts
@@ -41,10 +41,8 @@ import * as t from 'io-ts';
 export const createDefaultCodec = <C extends t.Mixed>(
   codec: C,
 ): t.TypeOf<C> => {
-  console.log({ codecName: codec.name });
   // If the codec is an union
   if (codec instanceof t.UnionType) {
-    console.log('union type');
     // The default for a union containing arrays is a default array
     const arrayType = codec.types.find(
       (type: any) => type instanceof t.ArrayType,
@@ -62,7 +60,6 @@ export const createDefaultCodec = <C extends t.Mixed>(
         type instanceof t.ArrayType,
     );
     if (objectType) {
-      console.log('objectType');
       return createDefaultCodec(objectType);
     }
 
@@ -71,7 +68,6 @@ export const createDefaultCodec = <C extends t.Mixed>(
       (type: any) => type instanceof t.NullType || type.name === 'null',
     );
     if (hasNull) {
-      console.log('hasNull');
       return null as t.TypeOf<C>;
     }
 

--- a/src/codecTools/createDefaultCodec.ts
+++ b/src/codecTools/createDefaultCodec.ts
@@ -41,8 +41,10 @@ import * as t from 'io-ts';
 export const createDefaultCodec = <C extends t.Mixed>(
   codec: C,
 ): t.TypeOf<C> => {
+  console.log({codecName: codec.name})
   // If the codec is an union
   if (codec instanceof t.UnionType) {
+    console.log("union type")
     // The default for a union containing arrays is a default array
     const arrayType = codec.types.find(
       (type: any) => type instanceof t.ArrayType,
@@ -60,6 +62,7 @@ export const createDefaultCodec = <C extends t.Mixed>(
         type instanceof t.ArrayType,
     );
     if (objectType) {
+      console.log("objectType")
       return createDefaultCodec(objectType);
     }
 
@@ -68,6 +71,7 @@ export const createDefaultCodec = <C extends t.Mixed>(
       (type: any) => type instanceof t.NullType || type.name === 'null',
     );
     if (hasNull) {
+      console.log("hasNull")
       return null as t.TypeOf<C>;
     }
 
@@ -109,6 +113,11 @@ export const createDefaultCodec = <C extends t.Mixed>(
     return (
       isObjectType ? [createDefaultCodec(elementType)] : []
     ) as t.TypeOf<C>;
+  }
+
+  // The default of a literal type is its value
+  if (codec instanceof t.LiteralType) {
+    return codec.value as t.TypeOf<C>;
   }
 
   // Handle primitive and common types

--- a/src/codecTools/createDefaultCodec.ts
+++ b/src/codecTools/createDefaultCodec.ts
@@ -41,10 +41,10 @@ import * as t from 'io-ts';
 export const createDefaultCodec = <C extends t.Mixed>(
   codec: C,
 ): t.TypeOf<C> => {
-  console.log({codecName: codec.name})
+  console.log({ codecName: codec.name });
   // If the codec is an union
   if (codec instanceof t.UnionType) {
-    console.log("union type")
+    console.log('union type');
     // The default for a union containing arrays is a default array
     const arrayType = codec.types.find(
       (type: any) => type instanceof t.ArrayType,
@@ -62,7 +62,7 @@ export const createDefaultCodec = <C extends t.Mixed>(
         type instanceof t.ArrayType,
     );
     if (objectType) {
-      console.log("objectType")
+      console.log('objectType');
       return createDefaultCodec(objectType);
     }
 
@@ -71,7 +71,7 @@ export const createDefaultCodec = <C extends t.Mixed>(
       (type: any) => type instanceof t.NullType || type.name === 'null',
     );
     if (hasNull) {
-      console.log("hasNull")
+      console.log('hasNull');
       return null as t.TypeOf<C>;
     }
 

--- a/src/tests/createDefaultCodec.test.ts
+++ b/src/tests/createDefaultCodec.test.ts
@@ -6,7 +6,7 @@ import { createDefaultCodec } from '../codecTools';
 
 chai.use(deepEqualInAnyOrder);
 
-describe('buildDefaultCodec', () => {
+describe.only('buildDefaultCodec', () => {
   it('should correctly build a default codec for null', () => {
     const result = createDefaultCodec(t.null);
     expect(result).to.equal(null);
@@ -30,6 +30,12 @@ describe('buildDefaultCodec', () => {
   it('should correctly build a default codec for string', () => {
     const result = createDefaultCodec(t.string);
     expect(result).to.equal('');
+  });
+
+  it('should correctly build a default codec for a union of literals', () => {
+    const codec = t.union([t.literal('A'), t.literal('B')]);
+    const defaultCodec = createDefaultCodec(codec);
+    expect(defaultCodec).to.equal('A');
   });
 
   it('should correctly build a default codec for a union with null', () => {

--- a/src/tests/createDefaultCodec.test.ts
+++ b/src/tests/createDefaultCodec.test.ts
@@ -6,7 +6,7 @@ import { createDefaultCodec } from '../codecTools';
 
 chai.use(deepEqualInAnyOrder);
 
-describe.only('buildDefaultCodec', () => {
+describe('buildDefaultCodec', () => {
   it('should correctly build a default codec for null', () => {
     const result = createDefaultCodec(t.null);
     expect(result).to.equal(null);


### PR DESCRIPTION
- before, `createDefaultCodec` of a union of literals returned null. Now, it returns the first literal value.