### PR TITLE
update createDefaultCodec to handle object types correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/codecTools/createDefaultCodec.ts
+++ b/src/codecTools/createDefaultCodec.ts
@@ -117,7 +117,14 @@ export const createDefaultCodec = <C extends t.Mixed>(
 
   // The default of a literal type is its value
   if (codec instanceof t.LiteralType) {
+    console.log(codec.name);
     return codec.value as t.TypeOf<C>;
+  }
+
+  // The default of an object type is an empty object
+  if (codec instanceof t.ObjectType) {
+    console.log(codec.name);
+    return {} as t.TypeOf<C>;
   }
 
   // Handle primitive and common types

--- a/src/codecTools/createDefaultCodec.ts
+++ b/src/codecTools/createDefaultCodec.ts
@@ -41,10 +41,8 @@ import * as t from 'io-ts';
 export const createDefaultCodec = <C extends t.Mixed>(
   codec: C,
 ): t.TypeOf<C> => {
-  console.log({codecName: codec.name})
   // If the codec is an union
   if (codec instanceof t.UnionType) {
-    console.log("union type")
     // The default for a union containing arrays is a default array
     const arrayType = codec.types.find(
       (type: any) => type instanceof t.ArrayType,
@@ -62,7 +60,6 @@ export const createDefaultCodec = <C extends t.Mixed>(
         type instanceof t.ArrayType,
     );
     if (objectType) {
-      console.log("objectType")
       return createDefaultCodec(objectType);
     }
 
@@ -71,7 +68,6 @@ export const createDefaultCodec = <C extends t.Mixed>(
       (type: any) => type instanceof t.NullType || type.name === 'null',
     );
     if (hasNull) {
-      console.log("hasNull")
       return null as t.TypeOf<C>;
     }
 
@@ -117,13 +113,11 @@ export const createDefaultCodec = <C extends t.Mixed>(
 
   // The default of a literal type is its value
   if (codec instanceof t.LiteralType) {
-    console.log(codec.name);
     return codec.value as t.TypeOf<C>;
   }
 
   // The default of an object type is an empty object
   if (codec instanceof t.ObjectType) {
-    console.log(codec.name);
     return {} as t.TypeOf<C>;
   }
 

--- a/src/codecTools/createDefaultCodec.ts
+++ b/src/codecTools/createDefaultCodec.ts
@@ -41,8 +41,10 @@ import * as t from 'io-ts';
 export const createDefaultCodec = <C extends t.Mixed>(
   codec: C,
 ): t.TypeOf<C> => {
+  console.log({codecName: codec.name})
   // If the codec is an union
   if (codec instanceof t.UnionType) {
+    console.log("union type")
     // The default for a union containing arrays is a default array
     const arrayType = codec.types.find(
       (type: any) => type instanceof t.ArrayType,
@@ -60,6 +62,7 @@ export const createDefaultCodec = <C extends t.Mixed>(
         type instanceof t.ArrayType,
     );
     if (objectType) {
+      console.log("objectType")
       return createDefaultCodec(objectType);
     }
 
@@ -68,6 +71,7 @@ export const createDefaultCodec = <C extends t.Mixed>(
       (type: any) => type instanceof t.NullType || type.name === 'null',
     );
     if (hasNull) {
+      console.log("hasNull")
       return null as t.TypeOf<C>;
     }
 

--- a/src/tests/createDefaultCodec.test.ts
+++ b/src/tests/createDefaultCodec.test.ts
@@ -6,7 +6,7 @@ import { createDefaultCodec } from '../codecTools';
 
 chai.use(deepEqualInAnyOrder);
 
-describe.only('buildDefaultCodec', () => {
+describe('buildDefaultCodec', () => {
   it('should correctly build a default codec for null', () => {
     const result = createDefaultCodec(t.null);
     expect(result).to.equal(null);
@@ -36,6 +36,12 @@ describe.only('buildDefaultCodec', () => {
     const codec = t.union([t.literal('A'), t.literal('B')]);
     const defaultCodec = createDefaultCodec(codec);
     expect(defaultCodec).to.equal('A');
+  });
+
+  it('should correctly build a default codec for an object', () => {
+    const codec = t.object;
+    const defaultCodec = createDefaultCodec(codec);
+    expect(defaultCodec).to.deep.equal({});
   });
 
   it('should correctly build a default codec for a union with null', () => {

--- a/src/tests/createDefaultCodec.test.ts
+++ b/src/tests/createDefaultCodec.test.ts
@@ -6,7 +6,7 @@ import { createDefaultCodec } from '../codecTools';
 
 chai.use(deepEqualInAnyOrder);
 
-describe('buildDefaultCodec', () => {
+describe.only('buildDefaultCodec', () => {
   it('should correctly build a default codec for null', () => {
     const result = createDefaultCodec(t.null);
     expect(result).to.equal(null);


### PR DESCRIPTION
- before, `createDefaultCodec` returned null for object types. Now, it returns an empty object.