### PR TITLE
Add new type for overriding nested fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,3 +258,6 @@ export type KeysStrictlyEqual<
       : never
     : never,
 > = Interface;
+
+/** Override fields in T with fields in U */
+export type Override<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;


### PR DESCRIPTION
Adds new generic type, Override, to simplify overriding fields in an existing type, particularly useful for GraphQL response structures.

Suppose an GQL response fields object like the following:
```
 {
  id: null,
  content: null,
  createdAt: null,
  author: {
    id: null,
    name: null,
    profilePicture: null,
  },
};
```
To make a type from this object, you might want to pick from the schema type:
```
export type AssessmentSectionCommentPreview = Pick<
  AssessmentSectionComment,
  keyof AssessmentSectionComment
> & {
  /** Subset of fields necessary for displaying the author */
  author?: Pick<User, 'id' | 'name' | 'profilePicture'>;
};
```
But here, `author` would not override the full author field from `AssessmentSectionComment`. You would have to first omit it like 

```
export type AssessmentSectionCommentPreview = Omit<Pick<
  AssessmentSectionComment,
  keyof AssessmentSectionComment
>, 'author'> & {
  /** Subset of fields necessary for displaying the author */
  author?: Pick<User, 'id' | 'name' | 'profilePicture'>;
};
```

This `Override` type makes this simpler by allowing us to do
```
export type AssessmentSectionCommentPreview = Override<Pick<
  AssessmentSectionComment,
  keyof AssessmentSectionComment
>, {
  /** Subset of fields necessary for displaying the author */
  author?: Pick<User, 'id' | 'name' | 'profilePicture'>;
}>;
```

See example usage: https://github.com/transcend-io/main/blob/ff458590e213f2af2bf8a80e73b13d561ef43528/frontend-services/admin-dashboard/src/DataMap/DataSilos/components/DataSilosTable/constants.ts#L329

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
