### PR TITLE
Fix imports from fp-ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/type-utils",
   "description": "Small package containing useful typescript utilities.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "https://github.com/transcend-io/type-utils",
   "repository": {
     "type": "git",

--- a/src/codecTools/decodeCodec.ts
+++ b/src/codecTools/decodeCodec.ts
@@ -1,5 +1,5 @@
-import { fold, isLeft } from 'fp-ts/Either';
-import { pipe } from 'fp-ts/pipeable';
+import { fold, isLeft } from 'fp-ts/lib/Either.js';
+import { pipe } from 'fp-ts/lib/pipeable.js';
 import * as t from 'io-ts';
 
 /**

--- a/src/codecTools/dictionary.ts
+++ b/src/codecTools/dictionary.ts
@@ -1,5 +1,5 @@
 // external
-import { unsafeCoerce } from 'fp-ts/function';
+import { unsafeCoerce } from 'fp-ts/lib/function.js';
 import * as t from 'io-ts';
 
 /** A record with optional keys */

--- a/src/noExcess.ts
+++ b/src/noExcess.ts
@@ -1,5 +1,5 @@
-import type { Either, Right } from 'fp-ts/Either';
-import { either, isRight, left, right } from 'fp-ts/Either';
+import type { Either, Right } from 'fp-ts/lib/Either.js';
+import { either, isRight, left, right } from 'fp-ts/lib/Either.js';
 import * as t from 'io-ts';
 
 /**

--- a/src/tests/createDefaultCodec.test.ts
+++ b/src/tests/createDefaultCodec.test.ts
@@ -1,10 +1,10 @@
 import * as t from 'io-ts';
-import chai, { expect } from 'chai';
+import { expect, use } from 'chai';
 import deepEqualInAnyOrder from 'deep-equal-in-any-order';
 
 import { createDefaultCodec } from '../codecTools/index.js';
 
-chai.use(deepEqualInAnyOrder);
+use(deepEqualInAnyOrder);
 
 describe('buildDefaultCodec', () => {
   it('should correctly build a default codec for null', () => {


### PR DESCRIPTION
Fix import for fp-ts package.
Fix import and usage for chai deep-equal-in-any-order

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
